### PR TITLE
chore: bump to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "beamium"
-version = "1.6.5"
+version = "1.7.0"
 dependencies = [
  "cast 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beamium"
-version = "1.6.5"
+version = "1.7.0"
 authors = [ "d33d33 <kevin.georges@corp.ovh.com>" ]
 
 build = "build.rs"


### PR DESCRIPTION
feat: add https support for scrapers