### PR TITLE
Fix double load of config file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -175,10 +175,8 @@ pub fn load_config(config_path: &str) -> Result<Config, ConfigError> {
         // Load from etc
         if Path::new("/etc/beamium/config.yaml").exists() {
             try!(load_path("/etc/beamium/config.yaml", &mut config));
-        }
-
-        // Load local
-        if Path::new("config.yaml").exists() {
+        } else if Path::new("config.yaml").exists() {
+            // Load local
             try!(load_path("config.yaml", &mut config));
         }
     } else {


### PR DESCRIPTION
Fixes #48 

On config load, if beamium is located at `/etc/beamium` and the config file is at the root of this directory, it will load the config file twice since the config will be both at `/etc/beamium/config.yaml` and at the root of beamium's local directory. This will cause beamium to load twice each sink and source in the configuration file, resulting in a race condition when it wants to move or remove a directory.
This PR aims at fixing this by not looking for a local config file if `/etc/beamium/config.yaml` is found.

Signed-off-by: Brendan Abolivier <contact@brendanabolivier.com>