### PR TITLE
Fix scraper name sent instead of headers'

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -290,7 +290,7 @@ fn load_path<P: AsRef<Path>>(file_path: P, config: &mut Config) -> Result<(), Co
                                 "scrapers.{}.headers.{} value should be a string",
                                 hname, name
                             )));
-                            ret.insert(String::from(name), String::from(value));
+                            ret.insert(String::from(hname), String::from(value));
                         }
 
                         ret


### PR DESCRIPTION
Fix a misused variable causing beamium to send headers with the scraper's name as the headers' keys.

Example configuration:

```
scrapers:
  scraper:
    url: http://127.0.0.1:9100/metrics
    format: prometheus
    period: 6000
    headers:
      Authorization: Basic XXXXX

[...]
```

Request sent without this patch:

```
GET /metrics HTTP/1.1
Host: 127.0.0.1:9100
scraper: Basic XXXXX
```

Request sent with this patch:

```
GET /metrics HTTP/1.1
Host: 127.0.0.1:9100
Authorization: Basic XXXXX
```