### PR TITLE
fix(sink): remove read/write timeout

### DIFF
--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -111,8 +111,6 @@ impl<'a> Sink<'a> {
                         // Handle connection timeouts
                         let mut tm = TimeoutConnector::new(connector, &handle);
                         tm.set_connect_timeout(Some(Duration::from_secs(timeout)));
-                        tm.set_read_timeout(Some(Duration::from_secs(timeout)));
-                        tm.set_write_timeout(Some(Duration::from_secs(timeout)));
 
                         let client = Arc::new(
                             hyper::Client::configure()


### PR DESCRIPTION
Current implementation is too aggresive against big payload
We need to have write timeout per chunk, not per post