### PR TITLE
add ca-certificates in docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN    apt-get update \
     && apt-get install -y --no-install-recommends \
         libssl-dev \
         beamium \
+        ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 CMD ["beamium"]


### PR DESCRIPTION
The docker image does not include certificates, thus an SSL error appears when pushing data to OVH sink. The PR add `ca-certificates` in Dockerfile.