### PR TITLE
feat(scraper_prometheus): skipping infinity values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "beamium"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beamium"
-version = "1.8.0"
+version = "1.8.1"
 authors = [ "d33d33 <kevin.georges@corp.ovh.com>" ]
 
 build = "build.rs"


### PR DESCRIPTION
In Prometheus, exporters can expose metrics with +Inf or -Inf as values.
As it is not standard values, we can skip them