### PR TITLE
Prometheus nan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "beamium"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "backoff 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beamium"
-version = "1.9.3"
+version = "1.9.4"
 authors = [ "d33d33 <kevin.georges@corp.ovh.com>" ]
 
 build = "build.rs"

--- a/src/lib/transcompiler.rs
+++ b/src/lib/transcompiler.rs
@@ -49,8 +49,8 @@ fn format_prometheus(line: &str, now: i64) -> Result<String, Box<Error>> {
 
     let value = tokens.next().ok_or("no value")?;
 
-    // Prometheus value can be '-Inf' or '+Inf', skipping if so
-    if value == "+Inf" || value == "-Inf" {
+    // Prometheus value can be '-Inf', '+Inf', 'nan', 'NaN' skipping if so
+    if value == "+Inf" || value == "-Inf" || value == "nan" || value == "NaN" {
         return Ok(String::new());
     }
 
@@ -105,6 +105,21 @@ mod tests {
         assert_eq!(expected.unwrap(), result.unwrap());
 
         let line = "f{job_id=\"123\"} -Inf";
+        let expected: Result<String, Box<Error>> = Ok(String::new());
+        let result = super::format_prometheus(line, 1);
+        assert_eq!(expected.is_ok(), result.is_ok());
+        assert_eq!(expected.unwrap(), result.unwrap());
+    }
+
+    #[test]
+    fn prometheus_skip_nan() {
+        let line = "f{job_id=\"123\"} nan";
+        let expected: Result<String, Box<Error>> = Ok(String::new());
+        let result = super::format_prometheus(line, 1);
+        assert_eq!(expected.is_ok(), result.is_ok());
+        assert_eq!(expected.unwrap(), result.unwrap());
+
+        let line = "f{job_id=\"123\"} NaN";
         let expected: Result<String, Box<Error>> = Ok(String::new());
         let result = super::format_prometheus(line, 1);
         assert_eq!(expected.is_ok(), result.is_ok());


### PR DESCRIPTION
Following issue #89 , that's the fix to skip nan and NaN values from prometheus before sending it on warp10.