### PR TITLE
fix(router) do not manage empty lines

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -146,4 +146,24 @@ mod tests {
         assert_eq!(expected.is_ok(), result.is_ok());
         assert_eq!(expected.unwrap(), result.unwrap());
     }
+
+    #[test]
+    fn add_one_label() {
+        let line = "1562656816000000// f{type=count} 1486";
+        let label = "host=foo";
+        let expected: Result<String, Error> = Ok(String::from("1562656816000000// f{host=foo,type=count} 1486"));
+        let result = super::add_labels(line, label);
+        assert_eq!(expected.is_ok(), result.is_ok());
+        assert_eq!(expected.unwrap(), result.unwrap());
+    }
+
+    #[test]
+    fn add_multiple_labels() {
+        let line = "1562656816000000// f{type=count} 1486";
+        let label = "host=foo,rack=toto";
+        let expected: Result<String, Error> = Ok(String::from("1562656816000000// f{host=foo,rack=toto,type=count} 1486"));
+        let result = super::add_labels(line, label);
+        assert_eq!(expected.is_ok(), result.is_ok());
+        assert_eq!(expected.unwrap(), result.unwrap());
+    }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -118,7 +118,9 @@ impl Router {
         let labels = labels.join(",");
         let mut body = vec![];
         for line in lines {
-            body.push(try_future!(add_labels(&line, &labels)))
+            if !line.is_empty() {
+                body.push(try_future!(add_labels(&line, &labels)))
+            }
         }
 
         ok(body)


### PR DESCRIPTION
Since beamium 2.0.0, when we add files directly on /opt/beamium/sources with the good syntax, importing file fails because of trying to parse an empty line if your file ends by \n

This fix removes empty lines before trying to add labels.