### PR TITLE
fix(hot-reload): handle runtime shutdown error in stream

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -221,18 +221,18 @@ pub(crate) fn main(
         }
     }
 
-    // Shutdown router runtime
-    debug!("shutdown router's runtime");
-    if router.1.shutdown_now().wait().is_err() {
-        error!("could not shutdown the router's runtime");
-    }
-
     // Shutdown runtime for each sinks
     for (sink, rt) in sinks {
         debug!("shutdown sink's runtime"; "sink" => sink.name());
         if rt.shutdown_now().wait().is_err() {
             error!("could not shutdown the runtime"; "sink" => sink.name());
         }
+    }
+
+    // Shutdown router runtime
+    debug!("shutdown router's runtime");
+    if router.1.shutdown_now().wait().is_err() {
+        error!("could not shutdown the router's runtime");
     }
 
     // Shutdown the metrics server

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,13 +156,7 @@ fn main(opts: Opts) -> Result<(), Error> {
         }
 
         // retrieve all pending events from watch
-        let watch_event_count = watcher_rx
-            .try_iter()
-            .map(|event| {
-                debug!("received a watch event '{:#?}'", event);
-                event
-            })
-            .count();
+        let watch_event_count = watcher_rx.try_iter().count();
 
         if watch_event_count > 0 {
             debug!("received a batch of {} watch events", watch_event_count);

--- a/src/router.rs
+++ b/src/router.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use failure::{format_err, Error};
-use futures::future::ok;
+use futures::future;
+use futures::future::{ExecuteErrorKind, Executor};
 use tokio::fs::remove_file;
 use tokio::fs::{rename, File};
 use tokio::prelude::*;
@@ -82,7 +83,7 @@ impl Runner for Router {
                     let epath = path.to_owned();
                     let state = acc.to_owned();
 
-                    executor.spawn(
+                    let result = executor.execute(
                         Self::load(path.to_owned())
                             .and_then(move |lines| Self::process(&lines, &labels))
                             .and_then(move |lines| Self::write(&lines, &params, &sinks))
@@ -101,11 +102,22 @@ impl Runner for Router {
                                 state.remove(&epath);
                             }),
                     );
+
+                    if let Err(err) = result {
+                        match err.kind() {
+                            ExecuteErrorKind::Shutdown => {
+                                warn!("could not execute the future, runtime is closed");
+                            },
+                            _ => {
+                                return future::err(format_err!("could not execute future, got runtime error"));
+                            }
+                        }
+                    }
                 }
 
-                ok::<_, Error>(acc)
+                future::ok(acc)
             })
-            .and_then(|_| ok(()))
+            .and_then(|_| future::ok(()))
             .map_err(|err| {
                 crit!("could not scan source directory"; "error" => err.to_string());
                 sleep(Duration::from_millis(100)); // Sleep the time to display the message
@@ -129,7 +141,7 @@ impl Router {
                 try_future!(file
                     .read_to_string(&mut buf)
                     .map_err(|err| format_err!("could not read file, {}", err)));
-                ok(buf.split('\n').map(String::from).collect())
+                future::ok(buf.split('\n').map(String::from).collect())
             })
     }
 
@@ -153,7 +165,7 @@ impl Router {
             }
         }
 
-        ok(body)
+        future::ok(body)
     }
 
     fn write(
@@ -215,13 +227,13 @@ impl Router {
             )
         }
 
-        future::join_all(bulk).and_then(|_| ok(()))
+        future::join_all(bulk).and_then(|_| future::ok(()))
     }
 
     fn remove(path: PathBuf) -> impl Future<Item = (), Error = Error> {
         trace!("remove file"; "path" => path.to_str());
         remove_file(path)
             .map_err(|err| format_err!("could not remove file, {}", err))
-            .and_then(|_| ok(()))
+            .and_then(|_| future::ok(()))
     }
 }


### PR DESCRIPTION
* The hot-reload feature allow the user to modify the configuration
  of beamium without restarting it. To do that, we closed every runtime
  started and re-create them. This could have as consequencies to
  spawn a future on a closed runtime when the current task of a runtime
  has not yet finished to run.
  As we are creating all the stuffs (queues, router, scrapers, sinks...),
  we could ignore this error, as we know the context.

Signed-off-by: Florentin Dubois <florentin.dubois@hey.com>